### PR TITLE
Add OpenAI integration with language detection

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,12 +1,9 @@
-import telebot
-import os
+from bot.commands import bot
 
-# Usa la variabile d’ambiente definita su Render
-bot = telebot.TeleBot(os.environ['TELEGRAM_TOKEN'])
-
-@bot.message_handler(commands=['start'])
-def send_welcome(message):
-    bot.reply_to(message, "Ciao, come posso aiutarti oggi?")
 
 def main():
     bot.infinity_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,0 +1,32 @@
+import os
+import openai
+import telebot
+
+from .utils import detect_language, get_subscription_level
+
+bot = telebot.TeleBot(os.environ['TELEGRAM_TOKEN'])
+
+@bot.message_handler(commands=['start'])
+def send_welcome(message):
+    bot.reply_to(message, "Ciao, sono Massimo AI! Scrivimi qualcosa.")
+
+@bot.message_handler(func=lambda m: True)
+def handle_message(message):
+    user_id = message.from_user.id
+    language = detect_language(message.text)
+    subscription = get_subscription_level(user_id)
+    reply = generate_openai_reply(message.text, language, subscription)
+    bot.reply_to(message, reply)
+
+
+def generate_openai_reply(text: str, language: str, subscription: str) -> str:
+    openai.api_key = os.environ.get('OPENAI_API_KEY')
+    prompt = text
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content.strip()
+    except Exception as e:
+        return f"Errore nella generazione della risposta: {e}"

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,16 @@
+import os
+from langdetect import detect
+
+# Example in-memory subscription data
+SUBSCRIPTIONS = {
+    # user_id: 'free' | 'premium'
+}
+
+def detect_language(text: str) -> str:
+    try:
+        return detect(text)
+    except Exception:
+        return 'unknown'
+
+def get_subscription_level(user_id: int) -> str:
+    return SUBSCRIPTIONS.get(user_id, os.environ.get('DEFAULT_SUBSCRIPTION', 'free'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyTelegramBotAPI==4.12.0
 Flask==2.3.2
 openai==1.82.1
 python-dotenv
+langdetect


### PR DESCRIPTION
## Summary
- restructure bot into `bot/` package
- add dynamic OpenAI responses with language detection and subscriptions
- add `langdetect` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482944aa6c8327a1220b827244ce51